### PR TITLE
Fix npm create command for npm 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check out [Convex docs](https://docs.convex.dev/home), and
 ## Setting up
 
 ```
-npm create convex@latest -- -t xixixao/saas-starter
+npx create-convex@latest  -t xixixao/saas-starter
 ```
 
 Then:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check out [Convex docs](https://docs.convex.dev/home), and
 ## Setting up
 
 ```
-npx create-convex@latest  -t xixixao/saas-starter
+npx create-convex@latest -t xixixao/saas-starter
 ```
 
 Then:


### PR DESCRIPTION
npm 11 broke passing through config flags with npm create.
Replaced 'npm create convex@latest --' with 'npx create-convex@latest'
and 'npm create convex --' with 'npx create-convex'.